### PR TITLE
ViewFix

### DIFF
--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -81,9 +81,18 @@
           position: absolute;
           top: 0;
           left: 530px;
+          height: 84px;
+          width: 470px;
+          overflow-x: auto;
+          white-space: nowrap;
+          -ms-overflow-style: none;
+          scrollbar-width: none;
           & img{
             border-radius: 10px;
           }
+        }
+        &favorite::-webkit-scrollbar {
+          display:none;
         }
       }
       .pagination{


### PR DESCRIPTION
# WHAT
お気に入りの靴が8個以上になった時にスクロールで対応できるよう修正。
# WHY
inlineblock要素で画像を表示していたので、横いっぱいになると下の段に新しい画像が移動してしまいビューが崩れるため