### PR TITLE
Basic認証解除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,14 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  # before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
-  def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == 'admin' && password == '3333'
-    end
-  end
+  # def basic_auth
+  #   authenticate_or_request_with_http_basic do |username, password|
+  #     username == 'admin' && password == '3333'
+  #   end
+  # end
   
   protected
 


### PR DESCRIPTION
# WHAT
Basic認証の解除
# WHY
ツイッターカードが表示されない原因の可能性がある為